### PR TITLE
fix(Softbreaks token): Only output break tags when the breaks option …

### DIFF
--- a/src/lib/renderer.js
+++ b/src/lib/renderer.js
@@ -75,7 +75,7 @@ const defaultTokens = {
   mark_open: 'mark',
   ordered_list_open: 'ol',
   paragraph_open: 'p',
-  softbreak: 'br',
+  softbreak: (_, options) => options.breaks ? 'br' : undefined,
   strong_open: 'strong',
   sub: 'sub',
   sup: 'sup',
@@ -94,24 +94,24 @@ function Renderer(options = {}) {
 
     components: {
       ...defaultComponents,
-      ...(options.components || {}),
+      ...options.components,
     },
 
     remarkableProps: {
       ...defaultRemarkableProps,
-      ...(options.remarkableProps || {}),
+      ...options.remarkableProps,
     },
 
     tokens: {
       ...defaultTokens,
-      ...(options.tokens || {}),
+      ...options.tokens,
     }
   };
 }
 
 Renderer.prototype.render = function(tokens = [], remarkableOptions) {
   return this.renderTokenTree(
-    buildTokenTree(this.options.tokens, tokens),
+    buildTokenTree(this.options.tokens, tokens, remarkableOptions),
     remarkableOptions);
 }
 

--- a/src/lib/token-tree-builder.js
+++ b/src/lib/token-tree-builder.js
@@ -15,9 +15,9 @@ function isInlineToken({ type }) {
   return type === INLINE_TYPE;
 }
 
-function getType(tokenMap, token) {
+function getType(tokenMap, token, options) {
   return typeof tokenMap[token.type] === 'function'
-    ? tokenMap[token.type](token)
+    ? tokenMap[token.type](token, options)
     : tokenMap[token.type];
 }
 
@@ -31,8 +31,8 @@ function expandToken(token, types) {
   }, null);
 }
 
-function buildToken(tokenMap, token) {
-  const type = getType(tokenMap, token);
+function buildToken(tokenMap, token, options) {
+  const type = getType(tokenMap, token, options);
 
   if (Array.isArray(type)) {
     return expandToken(token, type);
@@ -45,26 +45,26 @@ function buildToken(tokenMap, token) {
   };
 }
 
-function buildParentToken(tokenMap, tokens, index, level) {
+function buildParentToken(tokenMap, tokens, options, index, level) {
   return {
-    ...buildToken(tokenMap, tokens[index]),
-    children: buildTokenTree(tokenMap, tokens, index, level + 1),
+    ...buildToken(tokenMap, tokens[index], options),
+    children: buildTokenTree(tokenMap, tokens, options, index, level + 1),
   };
 }
 
-function buildTokenTree(tokenMap, tokens, index = -1, level = TOP_LEVEL) {
+function buildTokenTree(tokenMap, tokens, options, index = -1, level = TOP_LEVEL) {
   const collection = [];
 
   while (++index < tokens.length) {
     if (level === tokens[index].level) {
       if (isInlineToken(tokens[index])) {
-        return buildTokenTree(tokenMap, tokens[index].children);
+        return buildTokenTree(tokenMap, tokens[index].children, options);
       }
 
       if (isOpenToken(tokens[index])) {
-        collection.push(buildParentToken(tokenMap, tokens, index, level));
+        collection.push(buildParentToken(tokenMap, tokens, options, index, level));
       } else if (!isCloseToken(tokens[index])) {
-        collection.push(buildToken(tokenMap, tokens[index]));
+        collection.push(buildToken(tokenMap, tokens[index], options));
       }
     } else if (level !== TOP_LEVEL && level > tokens[index].level) {
       return collection;

--- a/test/renderer.tests.js
+++ b/test/renderer.tests.js
@@ -4,11 +4,11 @@ import { render, walkTree } from './utils';
 
 function assertStructure(input, expected) {
   walkTree(input, expected, (input, expected) => {
-    if (typeof input === 'string') {
-      assert.equal(input, expected);
+    if (!input || typeof input === 'string') {
+      assert.strictEqual(input, expected);
     } else {
       assert(isValidElement(input));
-      assert.equal(input.type, expected.type);
+      assert.strictEqual(input.type, expected.type);
     }
   });
 }
@@ -306,26 +306,37 @@ New\nLine
 
       `;
 
-      it('default', () => {
-        assertStructure(render(fixture), [{
-          type: 'p',
-          children: ['New', {
-            type: 'br',
-          }, 'Line'],
-        }]);
+      describe('with breaks true', () => {
+        it('default', () => {
+          assertStructure(render(fixture, { breaks: true }), [{
+            type: 'p',
+            children: ['New', {
+              type: 'br',
+            }, 'Line'],
+          }]);
+        });
+
+        it('custom', () => {
+          assertStructure(render(fixture, { breaks: true }, {
+            components: {
+              br: CustomComponent,
+            },
+          }), [{
+            type: 'p',
+            children: ['New', {
+              type: CustomComponent,
+            }, 'Line'],
+          }]);
+        });
       });
 
-      it('custom', () => {
-        assertStructure(render(fixture, {}, {
-          components: {
-            br: CustomComponent,
-          },
-        }), [{
-          type: 'p',
-          children: ['New', {
-            type: CustomComponent,
-          }, 'Line'],
-        }]);
+      describe('with breaks false', () => {
+        it('default', () => {
+          assertStructure(render(fixture, { breaks: false }, {}), [{
+            type: 'p',
+            children: ['New', undefined, 'Line'],
+          }]);
+        });
       });
     });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -33,6 +33,10 @@ function flatten(tree, flat = []) {
   return tree.reduce((flat, element) => {
     flat.push(element);
 
+    if (!element) {
+      return flat;
+    }
+
     if (element.props && Array.isArray(element.props.children)) {
       flatten(element.props.children, flat);
     }


### PR DESCRIPTION
…has been set to true

As shown in the unit tests, the following input ... 

```js
const remarkable = new Remarkable({ breaks: false });
remarkable.renderer = new RemarkableReactRenderer();

remarkable.render('New\nLine');
```

Will output the following React structure ... 

```js
ReactComponent('p', {
  children: ['New', undefined, 'Line'],
});
```

Because React ignores undefined children, it will output the following HTML...

```html
<p>NewLine</p>
```

And likewise `breaks: true` will output the same but with `<br />` tags...

```jsx
const remarkable = new Remarkable({ breaks: true });
remarkable.renderer = new RemarkableReactRenderer();
remarkable.render('New\nLine');

// ReactElement
ReactComponent('p', {
  children: ['New', ReactComponent('br'), 'Line'],
});

// HTML
<p>New<br />Line</p>
```