### PR TITLE
fix: enable returning boolean false from props mapping function

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -127,7 +127,7 @@ export default class Renderer {
         if (keyValue) {
           return {
             key: keyValue.key || prop,
-            value: keyValue.value || propValue,
+            value: keyValue.hasOwnProperty('value') ? keyValue.value : propValue,
           };
         }
       } else if (typeof this.options.remarkableProps[prop] === 'string') {

--- a/test/renderer.test.js
+++ b/test/renderer.test.js
@@ -1267,6 +1267,54 @@ Code
               }],
             }]);
           });
+
+          it('boolean value (true)', () => {
+            assertProps(render(`
+
+![](http://google.com "true")
+
+            `, {}, {
+              remarkableProps: {
+                title(value) {
+                  return {
+                    value: value && value.toLowerCase() == 'true',
+                  };
+                }
+              },
+            }), [{
+              children: [{
+                props: {
+                  alt: '',
+                  src: 'http://google.com',
+                  title: true,
+                },
+              }],
+            }]);
+          });
+
+          it('boolean value (false)', () => {
+            assertProps(render(`
+
+![](http://google.com "false")
+
+            `, {}, {
+              remarkableProps: {
+                title(value) {
+                  return {
+                    value: value && value.toLowerCase() == 'true',
+                  };
+                }
+              },
+            }), [{
+              children: [{
+                props: {
+                  alt: '',
+                  src: 'http://google.com',
+                  title: false,
+                },
+              }],
+            }]);
+          });
         });
 
         it('string', () => {


### PR DESCRIPTION
With current code if mapper function return { value: false } it will take original propValue.
this patch will take value key as is if exists.

P.S
would be great to get a new npm release after this is merged ^_^