### PR TITLE
Fix footnote ids and hrefs

### DIFF
--- a/src/defaultRemarkableProps.js
+++ b/src/defaultRemarkableProps.js
@@ -16,10 +16,10 @@ export default {
       case 'footnote_anchor':
         return {
           key: 'href',
-          value: `fn${id}:${token.subId || 0}`,
+          value: `#fn${id}:${token.subId || 0}`,
         };
       case 'footnote_open':
-        return { value: `#fn${id}` };
+        return { value: `fn${id}` };
       case 'footnote_ref':
         return type === 'a' ? ({
           key: 'href',

--- a/test/__snapshots__/Renderer.test.js.snap
+++ b/test/__snapshots__/Renderer.test.js.snap
@@ -76,12 +76,12 @@ Array [
   <section>
     <ol>
         <li
-            id="#fn0"
+            id="fn0"
         >
             <p>
                 Foonote body
                 <a
-                    href="fn0:0"
+                    href="#fn0:0"
                 >
                     ↩
                 </a>

--- a/test/__snapshots__/TokenTree.components.test.js.snap
+++ b/test/__snapshots__/TokenTree.components.test.js.snap
@@ -160,7 +160,7 @@ Array [
                   Object {
                     "children": "↩",
                     "props": Object {
-                      "href": "fn0:0",
+                      "href": "#fn0:0",
                     },
                     "type": "a",
                   },
@@ -170,7 +170,7 @@ Array [
               },
             ],
             "props": Object {
-              "id": "#fn0",
+              "id": "fn0",
             },
             "type": "li",
           },
@@ -239,7 +239,7 @@ Array [
               },
             ],
             "props": Object {
-              "id": "#fn0",
+              "id": "fn0",
             },
             "type": "li",
           },


### PR DESCRIPTION
The `#` prefix was swapped between the href and the id for footnotes.